### PR TITLE
fix hostname in documentation

### DIFF
--- a/docs/resources/flexmetal_server.md
+++ b/docs/resources/flexmetal_server.md
@@ -68,7 +68,7 @@ resource "i3dnet_flexmetal_server" "my-partitioned-server" {
 
 # Create a Talos OS 1.9.0 server
 resource "i3dnet_flexmetal_server" "my-talos" {
-  name          = "Talos Omni 1.9.0"
+  name          = "talosHostName"
   location      = "EU: Rotterdam"
   instance_type = "bm7.std.8"
   os = {

--- a/examples/resources/i3dnet_flexmetal_server/resource.tf
+++ b/examples/resources/i3dnet_flexmetal_server/resource.tf
@@ -53,7 +53,7 @@ resource "i3dnet_flexmetal_server" "my-partitioned-server" {
 
 # Create a Talos OS 1.9.0 server
 resource "i3dnet_flexmetal_server" "my-talos" {
-  name          = "Talos Omni 1.9.0"
+  name          = "talosHostName"
   location      = "EU: Rotterdam"
   instance_type = "bm7.std.8"
   os = {


### PR DESCRIPTION
Fix for 

```shell
╷
│ Error: API Response Error
│ 
│   with i3dnet_flexmetal_server.my-talos,
│   on main.tf line 17, in resource "i3dnet_flexmetal_server" "my-talos":
│   17: resource "i3dnet_flexmetal_server" "my-talos" {
│ 
│ API responded with non-2xx status: 422, reason: {"errorCode":11001,"errorMessage":"Errors in form","errors":[{"property":"name","message":"name must be a valid host domain name in
│ the format [xxx.]yyy.zzz"}]}, sent body: {"instanceType":"bm7.std.8","location":"EU: Rotterdam","name":"Talos Omni
│ 1.9.0","os":{"kernelParams":[{"key":"siderolink.api","value":"https://siderolink.api/?jointoken=secret"},{"key":"talos.customparam","value":"123456"}],"partitions":null,"slug":"talos-omni-190"},"postInstallScript":"","sshKey":[],"tags":[]}

```