### PR TITLE
Fix resource left dangling on timeout

### DIFF
--- a/internal/one_api/flexmetal_server.go
+++ b/internal/one_api/flexmetal_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -37,7 +36,32 @@ type Partition struct {
 	Size       int64  `json:"size"`
 }
 
-func (c *Client) CreateServer(ctx context.Context, req CreateServerReq) ([]byte, error) {
+type Server struct {
+	Uuid          string `json:"uuid"`
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	StatusMessage string `json:"statusMessage"`
+	Location      struct {
+		Id   int    `json:"id"`
+		Name string `json:"name"`
+	} `json:"location"`
+	InstanceType struct {
+		Id   int    `json:"id"`
+		Name string `json:"name"`
+	} `json:"instanceType"`
+	Os struct {
+		Slug string `json:"slug"`
+	} `json:"os"`
+	IpAddresses []struct {
+		IpAddress string `json:"ipAddress"`
+	} `json:"ipAddresses"`
+	Tags        []string `json:"tags"`
+	CreatedAt   int64    `json:"createdAt"`
+	DeliveredAt int64    `json:"deliveredAt"`
+	ReleasedAt  int64    `json:"releasedAt"`
+}
+
+func (c *Client) CreateServer(ctx context.Context, req CreateServerReq) (*Server, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling request: %w", err)
@@ -49,40 +73,55 @@ func (c *Client) CreateServer(ctx context.Context, req CreateServerReq) ([]byte,
 	}
 	defer resp.Close()
 
-	respBody, err := io.ReadAll(resp)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response: %w", err)
+	var serverResp []Server
+	dec := json.NewDecoder(resp)
+	if err := dec.Decode(&serverResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return respBody, nil
+	if len(serverResp) == 0 {
+		return nil, fmt.Errorf("unexpected empty response")
+	}
+
+	return &serverResp[0], nil
 }
 
-func (c *Client) GetServer(ctx context.Context, id string) ([]byte, error) {
+func (c *Client) GetServer(ctx context.Context, id string) (*Server, error) {
 	resp, err := c.callAPI(ctx, http.MethodGet, flexMetalEndpoint, fmt.Sprintf("servers/%s", id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error on calling get flexmetal server api: %w", err)
 	}
 	defer resp.Close()
 
-	respBody, err := io.ReadAll(resp)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response: %w", err)
+	var serverResp []Server
+	dec := json.NewDecoder(resp)
+	if err := dec.Decode(&serverResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return respBody, nil
+	if len(serverResp) == 0 {
+		return nil, fmt.Errorf("unexpected empty response")
+	}
+
+	return &serverResp[0], nil
 }
 
-func (c *Client) DeleteServer(ctx context.Context, id string) ([]byte, error) {
+func (c *Client) DeleteServer(ctx context.Context, id string) (*Server, error) {
 	resp, err := c.callAPI(ctx, http.MethodDelete, flexMetalEndpoint, fmt.Sprintf("servers/%s", id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error calling delete flexmetal server API: %w", err)
 	}
 	defer resp.Close()
 
-	respBody, err := io.ReadAll(resp)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response: %w", err)
+	var serverResp []Server
+	dec := json.NewDecoder(resp)
+	if err := dec.Decode(&serverResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return respBody, nil
+	if len(serverResp) == 0 {
+		return nil, fmt.Errorf("unexpected empty response")
+	}
+
+	return &serverResp[0], nil
 }

--- a/internal/provider/flexmetal_server_resource.go
+++ b/internal/provider/flexmetal_server_resource.go
@@ -199,7 +199,7 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 		}
 
 		serverRespToPlan(getServerResp, &data)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...) // todo do we need to append to state all time?
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/internal/provider/flexmetal_server_resource.go
+++ b/internal/provider/flexmetal_server_resource.go
@@ -184,6 +184,13 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	serverRespToPlan(createServerResp, &data)
 
+	// Add resource to TF state earlier to prevent dangling servers
+	// Example: timeout reached, but server is delivered later on
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Get the actual time
 	startTime := time.Now()
 


### PR DESCRIPTION
### Issue:


When creating a server resource, if it reaches the 30min timeout, the server is not saved into the state leaving it dangling. This is a problem because the dangling server can become `delivered` later, and customers would not be aware.

### Steps to reproduce:

Change de timeout from 30 min to 1 min. Rebuild locally the provider.
Run `terraform apply`
You should get a message in the form:

```shell
╷
│ Error: Server creation timeout
│ 
│   with i3dnet_flexmetal_server.valid-server,
│   on main.tf line 15, in resource "i3dnet_flexmetal_server" "valid-server":
│   15: resource "i3dnet_flexmetal_server" "valid-server" {
│ 
│ Server creation timeout
╵
```

After running `terraform show`, you would get:

```
The state file is empty. No resources are represented.
``` 

### Fix

Now, if you decrease the timeout with a local build of this PR, you will notice that even after reaching the timeout, the resource is saved into the state:

```shell
# i3dnet_flexmetal_server.valid-server: (tainted)
resource "i3dnet_flexmetal_server" "valid-server" {
    created_at     = 1738256369
    delivered_at   = 0
    instance_type  = "bm7.std.8"
    ip_addresses   = [
        {
            ip_address = "213.163.75.155"
        },
    ]
```


You will notice is **tainted**. Terraform marks an object as tainted in any situation where the provider or any related provisioner produced an error but the requested object was created anyway. In that case, Terraform can't be sure that the object is fully-functional as described in the configuration, and so it marks it as tainted to remember that the create needs to be retried on the next `terraform apply`.

This will be fix either:

- user runs `terraform apply` and the resource is re-created.
- if the user sees in admin that the server has been succesfully provisioned with status `delivered`, he can run `terraform refresh` and then mark as untained with `terraform untaint i3dnet_flexmetal_server.valid-server`
