### PR TITLE
Fix server update

### DIFF
--- a/internal/one_api/flexmetal_server.go
+++ b/internal/one_api/flexmetal_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -37,7 +36,32 @@ type Partition struct {
 	Size       int64  `json:"size"`
 }
 
-func (c *Client) CreateServer(ctx context.Context, req CreateServerReq) ([]byte, error) {
+type Server struct {
+	Uuid          string `json:"uuid"`
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	StatusMessage string `json:"statusMessage"`
+	Location      struct {
+		Id   int    `json:"id"`
+		Name string `json:"name"`
+	} `json:"location"`
+	InstanceType struct {
+		Id   int    `json:"id"`
+		Name string `json:"name"`
+	} `json:"instanceType"`
+	Os struct {
+		Slug string `json:"slug"`
+	} `json:"os"`
+	IpAddresses []struct {
+		IpAddress string `json:"ipAddress"`
+	} `json:"ipAddresses"`
+	Tags        []string `json:"tags"`
+	CreatedAt   int64    `json:"createdAt"`
+	DeliveredAt int64    `json:"deliveredAt"`
+	ReleasedAt  int64    `json:"releasedAt"`
+}
+
+func (c *Client) CreateServer(ctx context.Context, req CreateServerReq) (*Server, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling request: %w", err)
@@ -49,40 +73,55 @@ func (c *Client) CreateServer(ctx context.Context, req CreateServerReq) ([]byte,
 	}
 	defer resp.Close()
 
-	respBody, err := io.ReadAll(resp)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response: %w", err)
+	var serverResp []Server
+	dec := json.NewDecoder(resp)
+	if err := dec.Decode(&serverResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return respBody, nil
+	if len(serverResp) == 0 {
+		return nil, fmt.Errorf("unexpected empty response")
+	}
+
+	return &serverResp[0], nil
 }
 
-func (c *Client) GetServer(ctx context.Context, id string) ([]byte, error) {
+func (c *Client) GetServer(ctx context.Context, id string) (*Server, error) {
 	resp, err := c.callAPI(ctx, http.MethodGet, flexMetalEndpoint, fmt.Sprintf("servers/%s", id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error on calling get flexmetal server api: %w", err)
 	}
 	defer resp.Close()
 
-	respBody, err := io.ReadAll(resp)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response: %w", err)
+	var serverResp []Server
+	dec := json.NewDecoder(resp)
+	if err := dec.Decode(&serverResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return respBody, nil
+	if len(serverResp) == 0 {
+		return nil, fmt.Errorf("unexpected empty response")
+	}
+
+	return &serverResp[0], nil
 }
 
-func (c *Client) DeleteServer(ctx context.Context, id string) ([]byte, error) {
+func (c *Client) DeleteServer(ctx context.Context, id string) (*Server, error) {
 	resp, err := c.callAPI(ctx, http.MethodDelete, flexMetalEndpoint, fmt.Sprintf("servers/%s", id), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error calling delete flexmetal server API: %w", err)
 	}
 	defer resp.Close()
 
-	respBody, err := io.ReadAll(resp)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response: %w", err)
+	var serverResp []Server
+	dec := json.NewDecoder(resp)
+	if err := dec.Decode(&serverResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return respBody, nil
+	if len(serverResp) == 0 {
+		return nil, fmt.Errorf("unexpected empty response")
+	}
+
+	return &serverResp[0], nil
 }

--- a/internal/one_api/flexmetal_server.go
+++ b/internal/one_api/flexmetal_server.go
@@ -125,3 +125,43 @@ func (c *Client) DeleteServer(ctx context.Context, id string) (*Server, error) {
 
 	return &serverResp[0], nil
 }
+
+func (c *Client) AddTagToServer(ctx context.Context, serverID, tag string) (*Server, error) {
+	resp, err := c.callAPI(ctx, http.MethodPost, flexMetalEndpoint, fmt.Sprintf("servers/%s/tag/%s", serverID, tag), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error calling delete flexmetal server API: %w", err)
+	}
+	defer resp.Close()
+
+	var serverResp []Server
+	dec := json.NewDecoder(resp)
+	if err := dec.Decode(&serverResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
+	}
+
+	if len(serverResp) == 0 {
+		return nil, fmt.Errorf("unexpected empty response")
+	}
+
+	return &serverResp[0], nil
+}
+
+func (c *Client) DeleteTagFromServer(ctx context.Context, serverID, tag string) (*Server, error) {
+	resp, err := c.callAPI(ctx, http.MethodDelete, flexMetalEndpoint, fmt.Sprintf("servers/%s/tag/%s", serverID, tag), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error calling delete flexmetal server API: %w", err)
+	}
+	defer resp.Close()
+
+	var serverResp []Server
+	dec := json.NewDecoder(resp)
+	if err := dec.Decode(&serverResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
+	}
+
+	if len(serverResp) == 0 {
+		return nil, fmt.Errorf("unexpected empty response")
+	}
+
+	return &serverResp[0], nil
+}

--- a/internal/provider/flexmetal_server_resource.go
+++ b/internal/provider/flexmetal_server_resource.go
@@ -199,7 +199,7 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 		}
 
 		serverRespToPlan(getServerResp, &data)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...) // todo do we need to append to state all time?
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/internal/provider/flexmetal_server_resource.go
+++ b/internal/provider/flexmetal_server_resource.go
@@ -184,6 +184,13 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	serverRespToPlan(createServerResp, &data)
 
+	// Add resource to TF state earlier to prevent dangling servers
+	// Example: timeout reached, but server is delivered later on
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Get the actual time
 	startTime := time.Now()
 

--- a/internal/provider/modifiers/attributes.go
+++ b/internal/provider/modifiers/attributes.go
@@ -1,0 +1,21 @@
+package modifiers
+
+import (
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// UpdateComputed will modify Computed for attributes to value
+func UpdateComputed(s schema.Schema, attributes []string, value bool) {
+	for key, attribute := range s.Attributes {
+		if !slices.Contains(attributes, key) {
+			continue
+		}
+		switch v := attribute.(type) {
+		case schema.ListAttribute:
+			v.Computed = value
+			s.Attributes[key] = v
+		}
+	}
+}

--- a/internal/provider/modifiers/modifiers.go
+++ b/internal/provider/modifiers/modifiers.go
@@ -1,0 +1,56 @@
+package modifiers
+
+import (
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// ApplyRequireReplace applies a RequiresReplace plan modifier to resource attributes that cannot be updated in-place
+func ApplyRequireReplace(s schema.Schema, attributes []string) {
+	for key, attribute := range s.Attributes {
+		if !slices.Contains(attributes, key) {
+			continue
+		}
+		switch v := attribute.(type) {
+		case schema.StringAttribute:
+			v.PlanModifiers = append(v.PlanModifiers, stringplanmodifier.RequiresReplace())
+			s.Attributes[key] = v
+		case schema.ListAttribute:
+			v.PlanModifiers = append(v.PlanModifiers, listplanmodifier.RequiresReplace())
+			s.Attributes[key] = v
+		case schema.SingleNestedAttribute:
+			v.PlanModifiers = append(v.PlanModifiers, objectplanmodifier.RequiresReplace())
+			s.Attributes[key] = v
+		}
+	}
+}
+
+// ApplyUseStateForUnknown adds UseStateForUnknown() plan modifier to resource attributes
+//
+// UseStateForUnknown() Copies the prior state value, if not null.
+// This is useful for reducing (known after apply) plan outputs for computed
+// attributes which are known to not change over time.
+func ApplyUseStateForUnknown(s schema.Schema, attributes []string) {
+	for key, attribute := range s.Attributes {
+		if !slices.Contains(attributes, key) {
+			continue
+		}
+		switch v := attribute.(type) {
+		case schema.StringAttribute:
+			v.PlanModifiers = append(v.PlanModifiers, stringplanmodifier.UseStateForUnknown())
+			s.Attributes[key] = v
+		case schema.Int64Attribute:
+			v.PlanModifiers = append(v.PlanModifiers, int64planmodifier.UseStateForUnknown())
+			s.Attributes[key] = v
+		case schema.ListNestedAttribute:
+			v.PlanModifiers = append(v.PlanModifiers, listplanmodifier.UseStateForUnknown())
+			s.Attributes[key] = v
+		}
+	}
+}

--- a/internal/provider/tag_resource_test.go
+++ b/internal/provider/tag_resource_test.go
@@ -1,26 +1,31 @@
 package provider
 
 import (
+	"fmt"
+	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccTagResource(t *testing.T) {
+	tagName := randomTagName("tag")
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig(t) + `
+				Config: providerConfig(t) + fmt.Sprintf(`
 resource "i3dnet_tag" "test" {
-  name = "foo"
+  name = "%s"
 }
-`,
+`, tagName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify static values are set
-					resource.TestCheckResourceAttr("i3dnet_tag.test", "id", "foo"),
-					resource.TestCheckResourceAttr("i3dnet_tag.test", "name", "foo"),
+					resource.TestCheckResourceAttr("i3dnet_tag.test", "id", tagName),
+					resource.TestCheckResourceAttr("i3dnet_tag.test", "name", tagName),
 					resource.TestCheckResourceAttr("i3dnet_tag.test", "resources.count", "0"),
 					resource.TestCheckResourceAttr("i3dnet_tag.test", "resources.flex_metal_servers.count", "0"),
 				),
@@ -33,4 +38,8 @@ resource "i3dnet_tag" "test" {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
+
+func randomTagName(prefix string) string {
+	return prefix + strconv.Itoa(rand.Int())
 }

--- a/internal/provider/tags_data_source_test.go
+++ b/internal/provider/tags_data_source_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -11,24 +12,26 @@ import (
 )
 
 func TestAccTagDataSource(t *testing.T) {
-	createTestTags(t, "testTag", "secondTag")
+	firstTag := randomTagName("testTag")
+
+	createTestTags(t, firstTag, randomTagName("secondTag"))
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: providerConfig(t) + `
+				Config: providerConfig(t) + fmt.Sprintf(`
 data "i3dnet_tags" "fooTag" {
-  name = "testTag"
+  name = "%s"
 }
-`,
+`, firstTag),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify attributes
-					resource.TestCheckResourceAttr("data.i3dnet_tags.fooTag", "name", "testTag"),
+					resource.TestCheckResourceAttr("data.i3dnet_tags.fooTag", "name", firstTag),
 
 					resource.TestCheckResourceAttr("data.i3dnet_tags.fooTag", "tags.#", "1"),
-					resource.TestCheckResourceAttr("data.i3dnet_tags.fooTag", "tags.0.tag", "testTag"),
+					resource.TestCheckResourceAttr("data.i3dnet_tags.fooTag", "tags.0.tag", firstTag),
 					resource.TestCheckResourceAttr("data.i3dnet_tags.fooTag", "tags.0.resources.count", "0"),
 					resource.TestCheckResourceAttr("data.i3dnet_tags.fooTag", "tags.0.resources.flex_metal_servers.count", "0"),
 				),


### PR DESCRIPTION
This PR  contains https://github.com/i3D-net/terraform-provider-i3dnet/pull/17 + implementation of `i3dnet_flexmetal_server` method. Please refer to previous PR for the details of that fix there.

**Issue**

Our `i3dnet_flexmetal_server` resource doesn’t support updating. If a user creates a server and later on attempts to add new tags to it, we get following errors:

` Error: Provider returned invalid result object after apply`

**Fix**

If users update the `tags`  attribute of a server the `i3dnet_flexmetal_server` resource will be updated in place, otherwise the server will be replaced.