### PR TITLE
fix: initialize IpAddresses to known value when updating state

### DIFF
--- a/internal/provider/flexmetal_server_resource.go
+++ b/internal/provider/flexmetal_server_resource.go
@@ -240,6 +240,10 @@ func serverRespToPlan(ctx context.Context, serverResp *one_api.Server, data *res
 	data.Status = types.StringValue(serverResp.Status)
 	data.StatusMessage = types.StringValue(serverResp.StatusMessage)
 
+	data.IpAddresses = basetypes.NewListValueMust(
+		resource_flexmetal_server.IpAddressesValue{}.Type(context.Background()),
+		[]attr.Value{},
+	)
 	if len(serverResp.IpAddresses) > 0 {
 		var values []attr.Value
 		for _, ip := range serverResp.IpAddresses {


### PR DESCRIPTION
## Issue

When creating a server, if an error is encoutered and the `ipAddresses` returned from OneAPI is empty, then the state was saved in an invalid state(unknown value for for ip address) and the user would get following response:

```shell
        "After the apply operation, the provider still indicated an unknown value for",
        "i3dnet_flexmetal_server.linux[\"ubuntu-2404-lts-0\"].ip_addresses. All values",
        "must be known after apply, so this is always a bug in the provider and should",
        "be reported in the provider's own repository. Terraform will still save the",
        "other known object values in the state."
```       
        
## Fix

Initialize `IpAddresses` to a known value when parsing the reponse to state:

```go
	data.IpAddresses = basetypes.NewListValueMust(
		resource_flexmetal_server.IpAddressesValue{}.Type(context.Background()),
		[]attr.Value{},
	)
```