### PR TITLE
fix: improve errors display

### DIFF
--- a/internal/one_api/client.go
+++ b/internal/one_api/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -38,7 +37,7 @@ func NewClient(apiKey string, rawBaseURL string) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) callAPI(ctx context.Context, method, endpoint, path string, body []byte) (io.ReadCloser, error) {
+func (c *Client) callAPI(ctx context.Context, method, endpoint, path string, body []byte) (*http.Response, error) {
 	client := &http.Client{
 		Transport: &loggingRoundTripper{next: http.DefaultTransport, ctx: ctx},
 		Timeout:   10 * time.Second,
@@ -65,9 +64,5 @@ func (c *Client) callAPI(ctx context.Context, method, endpoint, path string, bod
 		return nil, fmt.Errorf("failed to do HTTP request: %w", err)
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("wrong status code received: %d", resp.StatusCode)
-	}
-
-	return resp.Body, nil
+	return resp, nil
 }

--- a/internal/one_api/locations.go
+++ b/internal/one_api/locations.go
@@ -24,10 +24,10 @@ func (c *Client) ListLocations(ctx context.Context) ([]Location, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error on calling list locations api: %w", err)
 	}
-	defer resp.Close()
+	defer resp.Body.Close()
 
 	var locationsResp []Location
-	dec := json.NewDecoder(resp)
+	dec := json.NewDecoder(resp.Body)
 	if err := dec.Decode(&locationsResp); err != nil {
 		return nil, fmt.Errorf("error decoding response: %w", err)
 	}

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -12,7 +12,7 @@ import (
 )
 
 func AddErrorResponseToDiags(message string, resp *one_api.ErrorResponse, diags *diag.Diagnostics) {
-	summary := fmt.Sprintf("%s", message)
+	summary := message
 	var details string
 
 	if len(resp.Errors) == 0 { // for duplicated tags, the error is not in resp.Errors but resp.ErrorMessage

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"terraform-provider-i3dnet/internal/one_api"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func AddErrorResponseToDiags(message string, resp *one_api.ErrorResponse, diags *diag.Diagnostics) {
+	summary := fmt.Sprintf("%s", message)
+	var details string
+
+	if len(resp.Errors) == 0 { // for duplicated tags, the error is not in resp.Errors but resp.ErrorMessage
+		details += fmt.Sprintf("Message: %s", firstUpper(resp.ErrorMessage))
+	}
+
+	for k, v := range resp.Errors {
+		details += fmt.Sprintf("Message: %s", strings.TrimRight(firstUpper(v.Message), ", "))
+		if k != len(resp.Errors)-1 {
+			details += "\n"
+		}
+	}
+	diags.AddError(summary, details)
+}
+
+// firstUpper returns a string with the first character as upper case.
+func firstUpper(s string) string {
+	if s == "" {
+		return ""
+	}
+	r, n := utf8.DecodeRuneInString(s)
+	return string(unicode.ToUpper(r)) + s[n:]
+}

--- a/internal/provider/ssh_key_data_source_test.go
+++ b/internal/provider/ssh_key_data_source_test.go
@@ -47,7 +47,7 @@ func createTestSSHKey(t *testing.T) {
 		t.Fatalf("error creating API Client: %s", err)
 	}
 
-	key, err := apiclient.CreateSSHKey(
+	response, err := apiclient.CreateSSHKey(
 		context.Background(),
 		one_api.CreateSSHKeyReq{
 			Name:      "TestApiKey",
@@ -58,7 +58,7 @@ func createTestSSHKey(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		err = apiclient.DeleteSSHKey(context.Background(), key.Uuid)
+		err = apiclient.DeleteSSHKey(context.Background(), response.SSHKey.Uuid)
 		if err != nil {
 			t.Fatalf("error deleting SSH Key: %s", err)
 		}


### PR DESCRIPTION
## About

This PR improves error messages display. Previously we would return a generic:

```sh
"Could not create server, unexpected error: error on calling create flexmetal server api: wrong status code received: 422" when trying to create the server using the terraform provider. "
```

Now, we try to parse ErrorResponse from One API, and return more context on the return errors.

## Error examples

When a required field is missing(name in this case):

```bash
│ Error: Missing required argument
│ 
│   on main.tf line 15, in resource "i3dnet_flexmetal_server" "my-talos":
│   15: resource "i3dnet_flexmetal_server" "my-talos" {
│ 
│ The argument "name" is required, but no definition was found.
```

When a field is invalid: ex. `instance_type`

```shell
╷
│ Error: Error creating server
│ 
│   with i3dnet_flexmetal_server.my-talos,
│   on main.tf line 15, in resource "i3dnet_flexmetal_server" "my-talos":
│   15: resource "i3dnet_flexmetal_server" "my-talos" {
│ 
│ Message: Invalid instanceType
```

When multiple fields are invalid:

```sh
i3dnet_flexmetal_server.my-talos: Creating...
╷
│ Error: Error creating server
│ 
│   with i3dnet_flexmetal_server.my-talos,
│   on main.tf line 15, in resource "i3dnet_flexmetal_server" "my-talos":
│   15: resource "i3dnet_flexmetal_server" "my-talos" {
│ 
│ Message: Invalid location
│ Message: Invalid instanceType
╵
```


When an invalid contract id(`INVALID`) is specified:

```shell
╷
│ Error: Error creating server
│ 
│   with i3dnet_flexmetal_server.my-talos,
│   on main.tf line 15, in resource "i3dnet_flexmetal_server" "my-talos":
│   15: resource "i3dnet_flexmetal_server" "my-talos" {
│ 
│ Message: Quota check failed: No quota found for contract id "INVALID"
```


When an unknown error happens(scenario: create talos without os params):

```sh
╷
│ Error: Server creation failed
│ 
│   with i3dnet_flexmetal_server.my-talos,
│   on main.tf line 15, in resource "i3dnet_flexmetal_server" "my-talos":
│   15: resource "i3dnet_flexmetal_server" "my-talos" {
│ 
│ Status message: Failed to start provisioning
╵
```



When a duplicated tag is created:

```sh
│ Error: Error creating tag
│ 
│   with i3dnet_tag.foo,
│   on main.tf line 14, in resource "i3dnet_tag" "foo":
│   14: resource "i3dnet_tag" "foo" {
│ 
│ Message: Tag foo already exists
```