### PR TITLE
feat(flexvm-vm): support tags on VM create

### DIFF
--- a/docs/resources/flexvm_vm.md
+++ b/docs/resources/flexvm_vm.md
@@ -25,6 +25,9 @@ resource "i3dnet_flexvm_vm" "my-vm" {
   instance_type_name = "vm.gpu.1rtx4000.15c.248g"
   image_name         = "ubuntu-2404-server-amd64"
   ssh_keys           = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHwdgjY0AlmkeLknBpoVmJg/quNSifyBHEK1MREpV4Ri john.doe@i3d.net"]
+
+  # Optional free-form labels for grouping in the monthly usage report.
+  tags = ["project:odyssey", "env:build"]
 }
 
 # Alternatively, provide cloud-init user-data from a file instead of ssh_keys.
@@ -54,6 +57,7 @@ resource "i3dnet_flexvm_vm" "my-vm-with-user-data" {
 
 - `description` (String) An optional free-form description of your VM.
 - `ssh_keys` (List of String) A list of public SSH keys. Exactly one of `ssh_keys` or `user_data_file` must be set.
+- `tags` (List of String) Free-form labels (e.g. `project:odyssey`, `env:build`) used for grouping in the monthly usage report. Each tag must be a non-empty string of at most 128 characters. Tags can only be set when the VM is created; changing them forces the VM to be replaced.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `user_data_file` (String) Path to a file whose contents are passed to the VM as cloud-init user-data on first boot. Exactly one of `ssh_keys` or `user_data_file` must be set; when `user_data_file` is used, configure SSH access through the user-data itself.
 

--- a/docs/resources/flexvm_vm.md
+++ b/docs/resources/flexvm_vm.md
@@ -57,7 +57,7 @@ resource "i3dnet_flexvm_vm" "my-vm-with-user-data" {
 
 - `description` (String) An optional free-form description of your VM.
 - `ssh_keys` (List of String) A list of public SSH keys. Exactly one of `ssh_keys` or `user_data_file` must be set.
-- `tags` (List of String) Free-form labels (e.g. `project:odyssey`, `env:build`) used for grouping in the monthly usage report. Each tag must be a non-empty string of at most 128 characters. Tags can only be set when the VM is created; changing them forces the VM to be replaced.
+- `tags` (List of String) Free-form labels (e.g. `project:odyssey`, `env:build`) used for grouping in the monthly usage report. When specified, at least one tag is required. Each tag must be a non-empty string of at most 128 characters. Tags can only be set when the VM is created; changing them forces the VM to be replaced.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `user_data_file` (String) Path to a file whose contents are passed to the VM as cloud-init user-data on first boot. Exactly one of `ssh_keys` or `user_data_file` must be set; when `user_data_file` is used, configure SSH access through the user-data itself.
 

--- a/examples/resources/i3dnet_flexvm_vm/resource.tf
+++ b/examples/resources/i3dnet_flexvm_vm/resource.tf
@@ -10,6 +10,9 @@ resource "i3dnet_flexvm_vm" "my-vm" {
   instance_type_name = "vm.gpu.1rtx4000.15c.248g"
   image_name         = "ubuntu-2404-server-amd64"
   ssh_keys           = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHwdgjY0AlmkeLknBpoVmJg/quNSifyBHEK1MREpV4Ri john.doe@i3d.net"]
+
+  # Optional free-form labels for grouping in the monthly usage report.
+  tags = ["project:odyssey", "env:build"]
 }
 
 # Alternatively, provide cloud-init user-data from a file instead of ssh_keys.

--- a/internal/one_api/flexvm.go
+++ b/internal/one_api/flexvm.go
@@ -28,6 +28,7 @@ type FlexvmCreateVMRequest struct {
 	ImageName        string          `json:"image_name,omitempty"`
 	SSHKeys          []string        `json:"ssh_keys,omitempty"`
 	UserData         *FlexvmUserData `json:"user_data,omitempty"`
+	Tags             []string        `json:"tags,omitempty"`
 }
 
 // FlexvmUserData is the cloud-init user-data passed to a VM on first boot.

--- a/internal/provider/flexvm_vm_resource.go
+++ b/internal/provider/flexvm_vm_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -57,6 +58,7 @@ type FlexvmVMModel struct {
 	ImageName        types.String   `tfsdk:"image_name"`
 	SSHKeys          types.List     `tfsdk:"ssh_keys"`
 	UserDataFile     types.String   `tfsdk:"user_data_file"`
+	Tags             types.List     `tfsdk:"tags"`
 	ID               types.String   `tfsdk:"id"`
 	Status           types.String   `tfsdk:"status"`
 	IPs              types.List     `tfsdk:"ips"`
@@ -175,6 +177,20 @@ func (r *flexvmVMResource) Schema(ctx context.Context, req resource.SchemaReques
 					"configuration file.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"tags": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				MarkdownDescription: "Free-form labels (e.g. `project:odyssey`, `env:build`) used for grouping in the " +
+					"monthly usage report. Each tag must be a non-empty string of at most 128 characters. Tags can " +
+					"only be set when the VM is created; changing them forces the VM to be replaced.",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.ValueStringsAre(stringvalidator.LengthBetween(1, 128)),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
 				},
 			},
 			"id": schema.StringAttribute{
@@ -353,6 +369,15 @@ func (r *flexvmVMResource) Create(ctx context.Context, req resource.CreateReques
 			return
 		}
 		createReq.SSHKeys = sshKeys
+	}
+
+	if !data.Tags.IsNull() {
+		var tags []string
+		resp.Diagnostics.Append(data.Tags.ElementsAs(ctx, &tags, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		createReq.Tags = tags
 	}
 
 	createTimeout, diags := data.Timeouts.Create(ctx, 10*time.Minute)

--- a/internal/provider/flexvm_vm_resource.go
+++ b/internal/provider/flexvm_vm_resource.go
@@ -183,8 +183,9 @@ func (r *flexvmVMResource) Schema(ctx context.Context, req resource.SchemaReques
 				ElementType: types.StringType,
 				Optional:    true,
 				MarkdownDescription: "Free-form labels (e.g. `project:odyssey`, `env:build`) used for grouping in the " +
-					"monthly usage report. Each tag must be a non-empty string of at most 128 characters. Tags can " +
-					"only be set when the VM is created; changing them forces the VM to be replaced.",
+					"monthly usage report. When specified, at least one tag is required. Each tag must be a non-empty " +
+					"string of at most 128 characters. Tags can only be set when the VM is created; changing them " +
+					"forces the VM to be replaced.",
 				Validators: []validator.List{
 					listvalidator.SizeAtLeast(1),
 					listvalidator.ValueStringsAre(stringvalidator.LengthBetween(1, 128)),

--- a/internal/provider/flexvm_vm_resource_test.go
+++ b/internal/provider/flexvm_vm_resource_test.go
@@ -29,6 +29,7 @@ resource "i3dnet_flexvm_vm" "test" {
   instance_type_name = "vm.4c.8g"
   image_name         = "ubuntu-2404-server-amd64"
   ssh_keys           = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHwdgjY0AlmkeLknBpoVmJg/quNSifyBHEK1MREpV4Ri john.doe@i3d.net"]
+  tags               = ["project:odyssey", "env:build"]
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -37,6 +38,9 @@ resource "i3dnet_flexvm_vm" "test" {
 						"terraform-gh-workflows-test"),
 					resource.TestCheckResourceAttr("i3dnet_flexvm_vm.test", "description",
 						"Terraform GitHub Workflows test"),
+					resource.TestCheckResourceAttr("i3dnet_flexvm_vm.test", "tags.#", "2"),
+					resource.TestCheckResourceAttr("i3dnet_flexvm_vm.test", "tags.0", "project:odyssey"),
+					resource.TestCheckResourceAttr("i3dnet_flexvm_vm.test", "tags.1", "env:build"),
 					resource.TestCheckResourceAttr("i3dnet_flexvm_vm.test", "instance_type.name",
 						"vm.4c.8g"),
 					resource.TestCheckResourceAttr("i3dnet_flexvm_vm.test", "image.name",
@@ -55,6 +59,7 @@ resource "i3dnet_flexvm_vm" "test" {
 					"instance_type_name",
 					"image_name",
 					"ssh_keys",
+					"tags",
 				},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs := s.RootModule().Resources["i3dnet_flexvm_vm.test"]


### PR DESCRIPTION
Add an optional create-only `tags` attribute to the `flexvm_vm` resource. Tags are validated as non-empty strings up to 128 chars and force replacement when changed, since the API only accepts them at create time.