### PR TITLE
fix(flexvm-node): bump default create timeout to 45m

### DIFF
--- a/internal/provider/flexvm_node_resource.go
+++ b/internal/provider/flexvm_node_resource.go
@@ -100,7 +100,7 @@ func (r *flexvmNodeResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	createTimeout, diags := data.Timeouts.Create(ctx, 30*time.Minute)
+	createTimeout, diags := data.Timeouts.Create(ctx, 45*time.Minute)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
Node provisioning could exceed the 30m default, causing Terraform to error with "Error waiting for FlexVM Cloud Node to be ready" even though the node came up successfully in the background.